### PR TITLE
Using gtrendsR behind a corporate PROXY

### DIFF
--- a/R/gtrends.R
+++ b/R/gtrends.R
@@ -101,7 +101,9 @@ gtrends <- function(
   time = "today+5-y", 
   gprop = c("web", "news", "images", "froogle", "youtube"), 
   category = 0,
-  hl = "en-US") {
+  hl = "en-US",
+  handle=NULL) {
+
   
   stopifnot(
     # One  vector should be a multiple of the other
@@ -153,17 +155,15 @@ gtrends <- function(
   # ****************************************************************************
   
   comparison_item <- data.frame(keyword, geo, time, stringsAsFactors = FALSE)
-  
-  widget <- get_widget(comparison_item, category, gprop, hl)
+  widget <- get_widget(comparison_item, category, gprop, hl, handle)
   
   # ****************************************************************************
   # Now that we have tokens, we can process the queries
   # ****************************************************************************
-  
-  interest_over_time <- interest_over_time(widget, comparison_item)
-  interest_by_region <- interest_by_region(widget, comparison_item)
-  related_topics <- related_topics(widget, comparison_item, hl)
-  related_queries <- related_queries(widget, comparison_item)
+  interest_over_time <- interest_over_time(widget, comparison_item, handle)
+  interest_by_region <- interest_by_region(widget, comparison_item, handle)
+  related_topics <- related_topics(widget, comparison_item, hl, handle)
+  related_queries <- related_queries(widget, comparison_item, handle)
     
   res <- list(
     interest_over_time = interest_over_time, 

--- a/R/related_queries.R
+++ b/R/related_queries.R
@@ -1,16 +1,15 @@
-related_queries <- function(widget, comparison_item) {
+related_queries <- function(widget, comparison_item, handle) {
   
   i <- which(grepl("queries", widget$title) == TRUE)
   
-  res <- lapply(i, create_related_queries_payload, widget = widget)
+  res <- lapply(i, create_related_queries_payload, widget = widget, handle)
   res <- do.call(rbind, res)
   
   return(res)
 }
 
 
-create_related_queries_payload <- function(i, widget) {
-  
+create_related_queries_payload <- function(i, widget, handle) {
   payload2 <- list()
   payload2$restriction$geo <-  as.list(widget$request$restriction$geo[i, , drop = FALSE])
   payload2$restriction$time <- widget$request$restriction$time[[i]]
@@ -31,8 +30,7 @@ create_related_queries_payload <- function(i, widget) {
   )
   
 
-  res <- curl::curl_fetch_memory(URLencode(url))
-  
+  res <- curl::curl_fetch_memory(URLencode(url), handle)
   stopifnot(res$status_code == 200)
   
   res <- readLines(textConnection(rawToChar(res$content)))

--- a/R/related_topics.R
+++ b/R/related_topics.R
@@ -1,16 +1,15 @@
-related_topics <- function(widget, comparison_item, hl) {
+related_topics <- function(widget, comparison_item, hl, handle) {
   
   i <- which(grepl("topics", widget$title) == TRUE)
   
-  res <- lapply(i, create_related_topics_payload, widget = widget, hl = hl)
+  res <- lapply(i, create_related_topics_payload, widget = widget, hl = hl, handle)
   res <- do.call(rbind, res)
   
   return(res)
 }
 
 
-create_related_topics_payload <- function(i, widget, hl) {
-  
+create_related_topics_payload <- function(i, widget, hl, handle) {
   payload2 <- list()
   payload2$restriction$geo <-  as.list(widget$request$restriction$geo[i, , drop = FALSE])
   payload2$restriction$time <- widget$request$restriction$time[[i]]
@@ -30,8 +29,7 @@ create_related_topics_payload <- function(i, widget, hl) {
     "&tz=300&hl=", hl
   )
   
-  res <- curl::curl_fetch_memory(URLencode(url))
-  
+  res <- curl::curl_fetch_memory(URLencode(url),handle=handle)
   stopifnot(res$status_code == 200)
   
   res <- readLines(textConnection(rawToChar(res$content)))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -55,7 +55,7 @@ check_time <- function(time) {
 }
 
 
-get_widget <- function(comparison_item, category, gprop, hl) {
+get_widget <- function(comparison_item, category, gprop, hl, handle) {
 
   token_payload <- list()
   token_payload$comparisonItem <- comparison_item
@@ -68,7 +68,7 @@ get_widget <- function(comparison_item, category, gprop, hl) {
                                               ## valid values do not change the result:
                                               ## clarification needed.
 
-  widget <- curl::curl_fetch_memory(url)
+  widget <- curl::curl_fetch_memory(url,handle)
 
   stopifnot(widget$status_code == 200)
 
@@ -83,8 +83,7 @@ get_widget <- function(comparison_item, category, gprop, hl) {
 
 }
 
-interest_over_time <- function(widget, comparison_item) {
-
+interest_over_time <- function(widget, comparison_item, handle) {
   payload2 <- list()
   payload2$locale <- widget$request$locale[1]
   payload2$comparisonItem <- widget$request$comparisonItem[[1]]
@@ -106,8 +105,7 @@ interest_over_time <- function(widget, comparison_item) {
   # Downoad the results
   # ****************************************************************************
 
-  res <- curl::curl_fetch_memory(URLencode(url))
-
+  res <- curl::curl_fetch_memory(URLencode(url), handle)
   stopifnot(res$status_code == 200)
 
   # ****************************************************************************
@@ -156,7 +154,7 @@ interest_over_time <- function(widget, comparison_item) {
 }
 
 
-interest_by_region <- function(widget, comparison_item) {
+interest_by_region <- function(widget, comparison_item, handle) {
 
   i <- which(grepl("Interest by", widget$title) == TRUE)
 
@@ -167,7 +165,7 @@ interest_by_region <- function(widget, comparison_item) {
 
   ## if searching within US metro, there is no region data. Return NULL.
   if (any(grepl("region", widget$title))) {
-    region <- lapply(i, create_geo_payload, widget = widget, resolution = resolution)
+    region <- lapply(i, create_geo_payload, widget = widget, resolution = resolution, handle)
     region <- do.call(rbind, region)
   } else {
     region <- NULL
@@ -175,14 +173,14 @@ interest_by_region <- function(widget, comparison_item) {
 
   ## US top metro
   if (any(grepl("metro", widget$title))) {
-    dma <- lapply(i, create_geo_payload, widget = widget, resolution = "DMA")
+    dma <- lapply(i, create_geo_payload, widget = widget, resolution = "DMA", handle)
     dma <- do.call(rbind, dma)
   } else {
     dma <- NULL
   }
 
   ## Top city
-  city <- lapply(i, create_geo_payload, widget = widget, resolution = "CITY")
+  city <- lapply(i, create_geo_payload, widget = widget, resolution = "CITY", handle)
   city <- do.call(rbind, city)
 
   res <- list(
@@ -195,7 +193,7 @@ interest_by_region <- function(widget, comparison_item) {
 }
 
 
-create_geo_payload <- function(i, widget, resolution) {
+create_geo_payload <- function(i, widget, resolution, handle) {
 
   payload2 <- list()
   payload2$locale <- unique(na.omit(widget$request$locale))
@@ -214,7 +212,7 @@ create_geo_payload <- function(i, widget, resolution) {
     "&tz=300&hl=en-US"
   )
 
-  res <- curl::curl_fetch_memory(URLencode(url))
+  res <- curl::curl_fetch_memory(URLencode(url), handle)
 
   stopifnot(res$status_code == 200)
 


### PR DESCRIPTION
A new parameter added to "gtrends" function allowing to use and set his own curl handle
Example :

library(gtrendsR)
library(curl)
hh<-new_handle()
handle_setopt(handle=hh,
					.list=list(ssl_verifypeer=0L,
					proxyuserpwd="<domain>\\<user>:<password>",
					proxyauth=9L,
					proxy="<proxy address>",
					proxyport=<porxyport>))
test = gtrends("sofoot", geo="FR",handle=hh)